### PR TITLE
research: change search link to go to the bottom

### DIFF
--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -29,7 +29,7 @@ layout: default
 %}
 
 {% capture search -%}
-  research/?search={% for alias in aliases %}"{{ alias }}" {% endfor %}
+  research/?search={% for alias in aliases %}"{{ alias }}" {% endfor %}#all
 {%- endcapture %}
 
 <p class="center">


### PR DESCRIPTION
This PR follows the first suggestion by @vincerubinetti [here](https://github.com/greenelab/lab-website-template/discussions/240#discussioncomment-8400957).